### PR TITLE
Extra methods and specializations

### DIFF
--- a/src/include/measurements.jl
+++ b/src/include/measurements.jl
@@ -3,3 +3,8 @@ export expectation_values
 function expectation_values(ρ::AbstractMatrix, base::AbstractMatrix)
     return sum(conj(base) .* (ρ * base), dims=1)[:]
 end
+
+# Hermitian matrices should yield real expectation values
+function expectation_values(ρ::Hermitian, base::AbstractMatrix)
+    return sum(real, conj(base) .* (ρ * base), dims=1)[:]
+end

--- a/src/include/measurements.jl
+++ b/src/include/measurements.jl
@@ -1,5 +1,5 @@
 export expectation_values
 
 function expectation_values(ρ::AbstractMatrix, base::AbstractMatrix)
-    return [ real(vec' * ρ * vec) for vec in eachcol(base) ]
+    return sum(conj(base) .* (ρ * base), dims=1)[:]
 end

--- a/src/include/tools/linear_algebra.jl
+++ b/src/include/tools/linear_algebra.jl
@@ -30,6 +30,28 @@ end
 
 issemiposdef(ρ::AbstractMatrix, tol=eps()) = isposdef(ρ + tol*I(size(ρ, 1)))
 
+
+function nearest_density(A::AbstractMatrix; tol=eps())
+    B = nearest_posdef(A; tol=tol)
+
+    return B / tr(B)
+
+function nearest_posdef(A::AbstractMatrix; tol=eps())
+    # Take Hermitian part of B
+    B = 0.5(A + A')
+
+    vals, vecs = eigen(Hermitian(B))
+
+    # Patch negative eigenvalues
+    vals = max.(vals, tol)
+
+    # Re-compose patched matrix
+    B = vecs * Diagonal(vals) * vecs'
+
+    # Positive definite is a subset of Hermitian matrices
+    return Hermitian(B)
+end
+
 """
     ptrace(M::AbstractMatrix, subsystem_sizes, trace_over)
 

--- a/src/include/tools/linear_algebra.jl
+++ b/src/include/tools/linear_algebra.jl
@@ -9,7 +9,7 @@ Notes
 =====
 * `trn(A) = (d*tr(A) - 1)/(d - 1)` where `d = size(A, 1)`.
 """
-function trn(A::AbstractMatrx)
+function trn(A::AbstractMatrix)
     d = size(A, 1)
 
     return (d*tr(A) - 1)/(d - 1)

--- a/src/include/tools/linear_algebra.jl
+++ b/src/include/tools/linear_algebra.jl
@@ -31,11 +31,6 @@ end
 issemiposdef(ρ::AbstractMatrix, tol=eps()) = isposdef(ρ + tol*I(size(ρ, 1)))
 
 
-function nearest_density(A::AbstractMatrix; tol=eps())
-    B = nearest_posdef(A; tol=tol)
-
-    return B / tr(B)
-
 function nearest_posdef(A::AbstractMatrix; tol=eps())
     # Take Hermitian part of B
     B = 0.5(A + A')
@@ -51,6 +46,14 @@ function nearest_posdef(A::AbstractMatrix; tol=eps())
     # Positive definite is a subset of Hermitian matrices
     return Hermitian(B)
 end
+
+
+function nearest_density(A::AbstractMatrix; tol=eps())
+    B = nearest_posdef(A; tol=tol)
+
+    return B / tr(B)
+end
+
 
 """
     ptrace(M::AbstractMatrix, subsystem_sizes, trace_over)

--- a/src/include/tools/linear_algebra.jl
+++ b/src/include/tools/linear_algebra.jl
@@ -31,6 +31,18 @@ end
 issemiposdef(ρ::AbstractMatrix, tol=eps()) = isposdef(ρ + tol*I(size(ρ, 1)))
 
 
+"""
+    nearest_posdef(A::AbstractMatrix; tol=eps())
+
+Computes the nearest Hermitian positive semidefinite matrix
+to `A` in the Frobenius norm, according to [1].
+The value of `tol` will be the smallest eigenvalue of the returned matrix.
+
+References
+==========
+[1] : "Computing a nearest symmetric positive semidefinite matrix" - N. J. Higham (1988)
+      https://doi.org/10.1016/0024-3795(88)90223-6
+"""
 function nearest_posdef(A::AbstractMatrix; tol=eps())
     # Take Hermitian part of B
     B = 0.5(A + A')
@@ -47,7 +59,13 @@ function nearest_posdef(A::AbstractMatrix; tol=eps())
     return Hermitian(B)
 end
 
+"""
+    nearest_density(A::AbstractMatrix; tol=eps())
 
+Computes the nearest density matrix to `A` in the Frobenius norm
+by first computing the nearest positive definite matrix with [`nearest_posdef`](@ref)
+and then trace-normalizing the result.
+"""
 function nearest_density(A::AbstractMatrix; tol=eps())
     B = nearest_posdef(A; tol=tol)
 

--- a/src/include/tools/linear_algebra.jl
+++ b/src/include/tools/linear_algebra.jl
@@ -1,4 +1,4 @@
-export trn, issemiposdef, ptrace
+export trn, issemiposdef, nearest_posdef, nearest_density, ptrace
 
 """
     trn(A::AbstractMatrx)

--- a/src/include/tools/linear_algebra.jl
+++ b/src/include/tools/linear_algebra.jl
@@ -1,4 +1,20 @@
-export issemiposdef, ptrace
+export trn, issemiposdef, ptrace
+
+"""
+    trn(A::AbstractMatrx)
+
+Returns the trace of `A` normalized to the interval `[0, 1]`.
+
+Notes
+=====
+* `trn(A) = (d*tr(A) - 1)/(d - 1)` where `d = size(A, 1)`.
+"""
+function trn(A::AbstractMatrx)
+    d = size(A, 1)
+
+    return (d*tr(A) - 1)/(d - 1)
+end
+
 
 """
     issquared(M::AbstractMatrix)


### PR DESCRIPTION
- add trn()
- faster calculation of expectation values for large matrices
- specialize expectation_values for Hermitian matrices
- add definitions for nearest_density() and nearest_posdef()
- fix trn()
- fix and reorder nearest_density and nearest_posdef
- export nearest_posdef() and nearest_density()
- add docs to nearest_posdef() and nearest_density()
